### PR TITLE
Add GPT-5 model support and env-based API defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and replace the placeholder with your actual OpenAI API key.
+OPENAI_API_KEY=sk-your-openai-api-key

--- a/README.md
+++ b/README.md
@@ -69,3 +69,79 @@ Generates graph
 ```
 python.exe .\gui.py
 ```
+
+## Dockerized Deployment
+
+The repository ships with a dockerized frontend (static web UI) and backend (FastAPI API) that expose the same graph generation pipeline used by the desktop application.
+
+### Prerequisites
+
+- Docker Engine 24+
+- Docker Compose v2
+- A valid `OPENAI_API_KEY` with access to the selected GPT model
+
+### Build and Run
+
+From the project root run:
+
+```bash
+docker compose up --build
+```
+
+The command builds two images:
+
+- `backend`: exposes the REST API on `http://localhost:8000`
+- `frontend`: serves the web UI on `http://localhost:3000`
+
+The stack reads environment variables from a local `.env` file if present. Copy `.env.example` to `.env` and populate `OPENAI_API_KEY` to avoid pasting your key every time you start the containers.
+
+The `OPENAI_API_KEY` environment variable is forwarded into the backend container automatically. You can also edit `docker-compose.yml` to hardcode a value.
+
+Two persistent Docker volumes keep generated artefacts:
+
+- `output-data`: HTML graph exports (mounted under `/app/output_graphs`)
+- `cache-data`: SQLite cache and extracted text (mounted under `/app/data_cache`)
+
+### Usage
+
+1. Open `http://localhost:3000` in your browser.
+2. Provide your OpenAI API key (it will be pre-filled automatically when `OPENAI_API_KEY` is set in `.env`) and select the desired options.
+3. Upload one or more PDF files and click **Generate Graphs**.
+4. When the job finishes, download the generated HTML files from the results list.
+
+> **Note**
+> The API does not stream intermediate responses. Check the status panel for log messages after the job completes.
+
+### Testing the containers live
+
+To validate that everything is running correctly:
+
+1. **Check container health**
+
+   ```bash
+   docker compose ps
+   ```
+
+   Both services should show the `running` state. You can follow their output with `docker compose logs -f backend frontend`.
+
+2. **Hit the API directly**
+
+   ```bash
+   curl http://localhost:8000/health
+   ```
+
+   A successful response returns `{"status":"ok"}`. This confirms the backend is ready to process requests.
+
+3. **Open the UI**
+
+   Navigate to `http://localhost:3000` and submit a small PDF. While the job runs you will see log updates in the browser and in the backend logs. When it completes, the UI exposes download links for the generated HTML graphs.
+
+4. **Inspect artefacts**
+
+   Generated files are written to the `output-data` volume. You can list them from the host with:
+
+   ```bash
+   docker compose run --rm backend ls /app/output_graphs
+   ```
+
+These steps let you smoke-test the full stack without leaving Docker.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+RUN touch /root/.hushlogin
+
+COPY requirements.txt ./requirements.txt
+
+RUN pip install --no-cache-dir -r requirements.txt && \
+    rm -rf /root/.cache/pip
+
+COPY . .
+
+ENV PYTHONPATH="/app/graph_extractor/src"
+
+EXPOSE 8000
+
+CMD ["uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,204 @@
+"""FastAPI application that exposes the graph generation pipeline as an HTTP API."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Dict, List
+
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+from dotenv import load_dotenv
+
+
+# ---------------------------------------------------------------------------
+#  Configure the import path so the API can reuse the existing graph pipeline
+# ---------------------------------------------------------------------------
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GRAPH_SRC = REPO_ROOT / "graph_extractor" / "src"
+
+if str(GRAPH_SRC) not in os.sys.path:
+    os.sys.path.insert(0, str(GRAPH_SRC))
+
+
+import abort_manager  # noqa: E402  (import after sys.path mutation)
+import config as cfg  # noqa: E402
+import graph_generator as gg  # noqa: E402
+import llm_api  # noqa: E402
+
+
+load_dotenv(dotenv_path=REPO_ROOT / ".env", override=False)
+
+
+API_DESCRIPTION = """REST API for the Knowledge Graph generator."""
+
+
+def _load_json_field(raw_value: str | None, field_name: str) -> Dict:
+    """Safely parse a JSON field from a multipart request."""
+
+    if raw_value in (None, ""):
+        return {}
+
+    try:
+        return json.loads(raw_value)
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
+        raise HTTPException(status_code=400, detail=f"Invalid JSON in '{field_name}': {exc}") from exc
+
+
+def _build_runtime_config(config_payload: Dict, options_payload: Dict) -> Dict:
+    """Merge the incoming config payload with the application's defaults."""
+
+    runtime_config = cfg.default_config.copy()
+    runtime_config.update(config_payload)
+
+    runtime_config.setdefault("config_file", "config.json")
+
+    # Build the extended configuration (adds internal defaults)
+    runtime_config = cfg.build_extended_config(runtime_config)
+
+    # Allow runtime overrides for UI specific flags
+    if "merge_document_graphs" in options_payload:
+        runtime_config["merge_document_graphs"] = bool(options_payload["merge_document_graphs"])
+
+    if "optimization_on" in options_payload:
+        runtime_config["optimization_on"] = bool(options_payload["optimization_on"])
+
+    if options_payload.get("resolution_state") == "high":
+        cfg.set_resolution(runtime_config, "high")
+    elif options_payload.get("resolution_state") == "normal":
+        cfg.set_resolution(runtime_config, "normal")
+
+    # Directories inside the container that are mounted as volumes via docker-compose
+    output_dir = Path(os.getenv("OUTPUT_DIR", runtime_config["output_folder"]))
+    internal_dir = Path(os.getenv("INTERNAL_DATA_DIR", runtime_config["internal_data_dir"]))
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    internal_dir.mkdir(parents=True, exist_ok=True)
+
+    runtime_config["output_folder"] = str(output_dir)
+    runtime_config["internal_data_dir"] = str(internal_dir)
+
+    cfg.detect_external_pdf_extractor_tool(runtime_config)
+
+    api_key = runtime_config.get("api_key") or os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise HTTPException(status_code=400, detail="Missing OpenAI API key. Provide it in the request or as OPENAI_API_KEY.")
+
+    runtime_config["api_key"] = api_key
+
+    return runtime_config
+
+
+app = FastAPI(title="Text to Graph Backend", description=API_DESCRIPTION, version="0.1.0")
+
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+OUTPUT_DIR = Path(os.getenv("OUTPUT_DIR", REPO_ROOT / "output_graphs"))
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+app.mount("/outputs", StaticFiles(directory=str(OUTPUT_DIR)), name="outputs")
+
+
+@app.get("/health")
+async def health_check() -> Dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/defaults")
+async def get_defaults() -> Dict[str, Dict[str, str] | List[str]]:
+    available_models = cfg.CONFIG_TEMPLATE.get("model", {}).get("allowed_values") or []
+    default_model = cfg.default_config.get("model") or (available_models[0] if available_models else "")
+
+    return {
+        "config": {
+            "api": cfg.default_config.get("api", "openai"),
+            "model": default_model,
+            "api_key": os.getenv("OPENAI_API_KEY", ""),
+        },
+        "models": available_models,
+    }
+
+
+def _progress_logger(logs: List[Dict[str, str]]):
+    def wrapper(message: str, type_name: str = "progress") -> None:
+        # Avoid leaking API keys or other sensitive values
+        if type_name == "log" and "api_key" in message.lower():
+            return
+        logs.append({"type": type_name, "message": message})
+
+    return wrapper
+
+
+@app.post("/generate")
+async def generate_graphs(
+    files: List[UploadFile] = File(description="One or more PDF documents."),
+    config: str | None = Form(default=None, description="JSON encoded configuration overrides."),
+    options: str | None = Form(default=None, description="JSON encoded UI flags."),
+):
+    if not files:
+        raise HTTPException(status_code=400, detail="At least one PDF file must be provided.")
+
+    config_payload = _load_json_field(config, "config")
+    options_payload = _load_json_field(options, "options")
+
+    runtime_config = _build_runtime_config(config_payload, options_payload)
+
+    abort_manager.ABORT_FLAG = False
+    llm_api.set_llm_config(runtime_config)
+
+    progress_entries: List[Dict[str, str]] = []
+    callback = _progress_logger(progress_entries)
+
+    upload_dir = Path(tempfile.mkdtemp(prefix="uploads_", dir=runtime_config["internal_data_dir"]))
+
+    stored_files: List[Path] = []
+    try:
+        for upload in files:
+            if upload.content_type not in {"application/pdf", "application/octet-stream", None}:
+                raise HTTPException(status_code=400, detail=f"Unsupported file type: {upload.content_type}")
+
+            safe_name = Path(upload.filename or "document.pdf").name
+            destination = upload_dir / safe_name
+
+            with destination.open("wb") as buffer:
+                while chunk := await upload.read(1024 * 1024):
+                    buffer.write(chunk)
+
+            stored_files.append(destination)
+
+        existing_outputs = {p.name for p in Path(runtime_config["output_folder"]).glob("*.html")}
+
+        await gg.generate_graph_async([str(path) for path in stored_files], runtime_config, callback)
+
+        new_outputs = [
+            str(Path("/outputs") / path.name)
+            for path in Path(runtime_config["output_folder"]).glob("*.html")
+            if path.name not in existing_outputs
+        ]
+
+        return {
+            "status": "completed",
+            "outputs": new_outputs,
+            "logs": progress_entries,
+        }
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - executed in runtime, not during tests
+        callback(f"{exc}", "error")
+        raise HTTPException(status_code=500, detail="Graph generation failed.") from exc
+    finally:
+        shutil.rmtree(upload_dir, ignore_errors=True)
+        abort_manager.ABORT_FLAG = False
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "3.9"
+
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    env_file:
+      - .env
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - OUTPUT_DIR=/app/output_graphs
+      - INTERNAL_DATA_DIR=/app/data_cache
+    volumes:
+      - output-data:/app/output_graphs
+      - cache-data:/app/data_cache
+    ports:
+      - "8000:8000"
+
+  frontend:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+    depends_on:
+      - backend
+    ports:
+      - "3000:80"
+
+volumes:
+  output-data:
+  cache-data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:1.27-alpine
+
+COPY frontend /usr/share/nginx/html
+
+EXPOSE 80

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Knowledge Graph Generator</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+
+<body>
+  <main class="container">
+    <header>
+      <h1>Knowledge Graph Generator</h1>
+      <p class="subtitle">Upload PDF documents, configure the LLM options, and generate interactive knowledge graphs.</p>
+      <p id="health-indicator" class="health health--unknown">Checking backend status…</p>
+    </header>
+
+    <section class="card">
+      <form id="generate-form">
+        <fieldset>
+          <legend>OpenAI Configuration</legend>
+          <div class="form-row">
+            <label for="api-key">API Key</label>
+            <input type="password" id="api-key" name="api-key" autocomplete="off" required />
+          </div>
+
+          <div class="form-row">
+            <label for="model">Model</label>
+            <select id="model" name="model">
+              <option value="gpt-5-mini">gpt-5-mini</option>
+              <option value="gpt-5-nano">gpt-5-nano</option>
+              <option value="gpt-5">gpt-5</option>
+            </select>
+          </div>
+        </fieldset>
+
+        <fieldset>
+          <legend>Generation Options</legend>
+          <div class="form-row">
+            <label class="checkbox">
+              <input type="checkbox" id="merge-graphs" />
+              Combine graphs from all documents into one output
+            </label>
+          </div>
+          <div class="form-row">
+            <label class="checkbox">
+              <input type="checkbox" id="enable-cache" checked />
+              Enable caching to reuse previous responses
+            </label>
+          </div>
+
+          <div class="form-row">
+            <label for="resolution">Resolution</label>
+            <select id="resolution">
+              <option value="normal">Normal</option>
+              <option value="high">High Detail</option>
+            </select>
+          </div>
+        </fieldset>
+
+        <fieldset>
+          <legend>Documents</legend>
+          <div class="form-row">
+            <label for="pdf-files">PDF Files</label>
+            <input type="file" id="pdf-files" name="files" accept="application/pdf" multiple required />
+          </div>
+        </fieldset>
+
+        <button type="submit" id="submit-button">Generate Graphs</button>
+      </form>
+    </section>
+
+    <section class="card" id="status-card">
+      <h2>Status</h2>
+      <pre id="log-output" class="log-output">Waiting for a job…</pre>
+    </section>
+
+    <section class="card" id="results-card">
+      <h2>Generated Graphs</h2>
+      <p id="results-help">The download links will appear here after a successful run.</p>
+      <ul id="results-list"></ul>
+    </section>
+  </main>
+
+  <script src="script.js" defer></script>
+</body>
+
+</html>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,0 +1,181 @@
+const API_BASE = `${window.location.protocol}//${window.location.hostname}:8000`;
+
+const healthIndicator = document.getElementById("health-indicator");
+const form = document.getElementById("generate-form");
+const submitButton = document.getElementById("submit-button");
+const logOutput = document.getElementById("log-output");
+const resultsHelp = document.getElementById("results-help");
+const resultsList = document.getElementById("results-list");
+const apiKeyInput = document.getElementById("api-key");
+const modelSelect = document.getElementById("model");
+
+async function checkHealth() {
+  try {
+    const response = await fetch(`${API_BASE}/health`);
+    if (!response.ok) {
+      throw new Error("Unexpected response");
+    }
+    healthIndicator.textContent = "Backend is online";
+    healthIndicator.className = "health health--ok";
+  } catch (error) {
+    console.error(error);
+    healthIndicator.textContent = "Backend is offline";
+    healthIndicator.className = "health health--error";
+  }
+}
+
+function resetLogs() {
+  logOutput.textContent = "Waiting for a job…";
+  resultsHelp.style.display = "block";
+  resultsList.innerHTML = "";
+}
+
+function appendLogs(entries) {
+  if (!entries || entries.length === 0) {
+    logOutput.textContent = "No log entries were returned.";
+    return;
+  }
+
+  const content = entries
+    .map(({ type, message }) => `[${type.toUpperCase()}] ${message}`)
+    .join("\n");
+
+  logOutput.textContent = content;
+}
+
+function updateResults(outputs) {
+  resultsList.innerHTML = "";
+
+  if (!outputs || outputs.length === 0) {
+    resultsHelp.style.display = "block";
+    return;
+  }
+
+  resultsHelp.style.display = "none";
+
+  outputs.forEach((href) => {
+    const listItem = document.createElement("li");
+    const link = document.createElement("a");
+    link.href = `${API_BASE}${href}`;
+    link.target = "_blank";
+    link.rel = "noopener";
+    link.textContent = href.split("/").pop();
+    listItem.appendChild(link);
+    resultsList.appendChild(listItem);
+  });
+}
+
+function collectFormData() {
+  const formData = new FormData();
+
+  const apiKey = apiKeyInput.value.trim();
+  const model = modelSelect.value;
+  const mergeGraphs = document.getElementById("merge-graphs").checked;
+  const enableCache = document.getElementById("enable-cache").checked;
+  const resolution = document.getElementById("resolution").value;
+  const files = document.getElementById("pdf-files").files;
+
+  if (!apiKey) {
+    throw new Error("API key is required.");
+  }
+
+  if (!files || files.length === 0) {
+    throw new Error("Please select at least one PDF file.");
+  }
+
+  const configPayload = {
+    api_key: apiKey,
+    model,
+    api: "openai",
+  };
+
+  const optionsPayload = {
+    merge_document_graphs: mergeGraphs,
+    optimization_on: enableCache,
+    resolution_state: resolution,
+  };
+
+  formData.append("config", JSON.stringify(configPayload));
+  formData.append("options", JSON.stringify(optionsPayload));
+
+  Array.from(files).forEach((file) => {
+    formData.append("files", file, file.name);
+  });
+
+  return formData;
+}
+
+async function submitJob(event) {
+  event.preventDefault();
+
+  try {
+    const payload = collectFormData();
+    logOutput.textContent = "Uploading documents and starting the job…";
+    submitButton.disabled = true;
+    submitButton.textContent = "Processing…";
+
+    const response = await fetch(`${API_BASE}/generate`, {
+      method: "POST",
+      body: payload,
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      throw new Error(data.detail || "Request failed");
+    }
+
+    appendLogs(data.logs);
+    updateResults(data.outputs);
+  } catch (error) {
+    logOutput.textContent = `Error: ${error.message}`;
+    resultsHelp.style.display = "block";
+    resultsList.innerHTML = "";
+  } finally {
+    submitButton.disabled = false;
+    submitButton.textContent = "Generate Graphs";
+  }
+}
+
+async function hydrateDefaults() {
+  try {
+    const response = await fetch(`${API_BASE}/defaults`);
+    if (!response.ok) {
+      throw new Error("Failed to fetch defaults");
+    }
+
+    const data = await response.json();
+
+    if (Array.isArray(data.models) && data.models.length > 0) {
+      modelSelect.innerHTML = "";
+      data.models.forEach((modelName) => {
+        const option = document.createElement("option");
+        option.value = modelName;
+        option.textContent = modelName;
+        modelSelect.appendChild(option);
+      });
+    }
+
+    if (data.config) {
+      if (typeof data.config.api_key === "string" && data.config.api_key.length > 0) {
+        apiKeyInput.value = data.config.api_key;
+      }
+
+      if (typeof data.config.model === "string" && data.config.model.length > 0) {
+        const desiredOption = Array.from(modelSelect.options).find(
+          (option) => option.value === data.config.model,
+        );
+        if (desiredOption) {
+          modelSelect.value = data.config.model;
+        }
+      }
+    }
+  } catch (error) {
+    console.warn("Unable to load defaults", error);
+  }
+}
+
+resetLogs();
+checkHealth();
+hydrateDefaults();
+form.addEventListener("submit", submitJob);

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,177 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.5;
+  background-color: #0b0b0f;
+  color: #f6f6f9;
+}
+
+body {
+  margin: 0;
+  padding: 2rem 1rem 4rem;
+  display: flex;
+  justify-content: center;
+}
+
+.container {
+  width: min(960px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+header {
+  text-align: center;
+}
+
+.subtitle {
+  margin-top: 0.5rem;
+  color: #c2c6e1;
+}
+
+.card {
+  background: #11121a;
+  border: 1px solid #1f2233;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 40px rgba(9, 11, 22, 0.35);
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+fieldset {
+  border: 1px solid #1f2233;
+  border-radius: 12px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+legend {
+  padding: 0 0.5rem;
+  font-weight: 600;
+}
+
+.form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+label {
+  font-weight: 500;
+}
+
+.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 400;
+}
+
+input[type="text"],
+input[type="password"],
+select,
+input[type="file"] {
+  padding: 0.6rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid #2a2d44;
+  background: #181a26;
+  color: inherit;
+}
+
+input[type="file"]::-webkit-file-upload-button {
+  padding: 0.4rem 0.9rem;
+  margin-right: 0.75rem;
+  border-radius: 8px;
+  border: none;
+  background: #3f5efb;
+  color: white;
+  cursor: pointer;
+}
+
+button {
+  padding: 0.8rem 1rem;
+  border-radius: 12px;
+  border: none;
+  background: linear-gradient(135deg, #7f53ac, #647dee);
+  color: white;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+button:not(:disabled):hover {
+  transform: translateY(-1px);
+}
+
+.log-output {
+  background: #0d0f18;
+  border: 1px solid #24273d;
+  border-radius: 12px;
+  padding: 1rem;
+  min-height: 200px;
+  overflow-x: auto;
+  font-family: "Roboto Mono", "Fira Code", monospace;
+  font-size: 0.9rem;
+  white-space: pre-wrap;
+}
+
+#results-list {
+  margin: 0;
+  padding-left: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+#results-list a {
+  color: #8ab4ff;
+  text-decoration: none;
+}
+
+#results-list a:hover {
+  text-decoration: underline;
+}
+
+.health {
+  font-weight: 600;
+  margin-top: 1rem;
+}
+
+.health--ok {
+  color: #5ae08a;
+}
+
+.health--error {
+  color: #ff6b6b;
+}
+
+.health--unknown {
+  color: #ffd166;
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 1.5rem 1rem 3rem;
+  }
+
+  fieldset {
+    padding: 0.75rem;
+  }
+
+  button {
+    width: 100%;
+  }
+}

--- a/graph_extractor/src/config.py
+++ b/graph_extractor/src/config.py
@@ -11,7 +11,7 @@ default_config = {
     'api_key': '',
     'api': 'openai',
     'doc_parser_tool': '',
-    'model': 'gpt-4o-mini',
+    'model': 'gpt-5-mini',
     'llm_timeout': 60,
     'max_concurrent_requests': 5,
     'config_file': 'config.json'
@@ -42,7 +42,7 @@ CONFIG_TEMPLATE = {
     "model": {
         "required": True,
         "type": str,
-        "allowed_values": ["gpt-4o-mini", "gpt-4o", "gpt-4o-2024-11-20"],
+        "allowed_values": ["gpt-5-mini", "gpt-5-nano", "gpt-5"],
         "range": None,
         "allow_empty": False,
     },
@@ -199,10 +199,13 @@ def set_resolution(config, resolution):
         config['padding_size'] = 1
 
     if config['padding_size'] > 0:
-        config['max_tokens'] = 2 * int(config['chunk_size'] + 2 * config['padding_size'] * config['chunk_size'])
+        token_budget = 2 * int(config['chunk_size'] + 2 * config['padding_size'] * config['chunk_size'])
     else:
         config['overlap'] = 100
-        config['max_tokens'] = 3 * int(config['chunk_size'] + 2 * config['overlap'])
+        token_budget = 3 * int(config['chunk_size'] + 2 * config['overlap'])
+
+    config['max_tokens'] = token_budget
+    config['max_completion_tokens'] = token_budget
 
 
 def build_extended_config(config):

--- a/graph_extractor/src/sqlite_support.py
+++ b/graph_extractor/src/sqlite_support.py
@@ -536,7 +536,7 @@ def main():
 
     config_id = get_or_create_config_id(
         api='openai',
-        model='gpt-4o-mini',
+        model='gpt-5-mini',
         temperature=0,
         top_p=0.3,
         chunk_size=1000,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,14 @@ pandas
 requests
 openai
 tiktoken
-psycopg2
+psycopg2-binary
+python-dotenv
 pdfplumber
 pyinstaller
 pyarmor
 csscompressor
 htmlmin
 ttkbootstrap
+fastapi
+uvicorn[standard]
+python-multipart


### PR DESCRIPTION
## Summary
- switch configuration defaults and validation to GPT-5 models and update the OpenAI client to use `max_completion_tokens` when required
- expose a `/defaults` endpoint, auto-populate the frontend form from environment-provided API keys, and add `.env` scaffolding for Docker setups
- document the new `.env` workflow and ensure docker-compose loads it automatically

## Testing
- python -m compileall backend/app/main.py

------
https://chatgpt.com/codex/tasks/task_e_68e60902502c8320a0d12f7ba026c5dd